### PR TITLE
fix: import modules used by bootstrap script

### DIFF
--- a/whisper_gui_bootstrap.py
+++ b/whisper_gui_bootstrap.py
@@ -14,7 +14,7 @@ Whisper Live Caption – GUI with One-Click Bootstrap
 """
 
 from __future__ import annotations
-import importlib.util, subprocess, sys
+import importlib.util, subprocess, sys, os, re, queue, threading
 if importlib.util.find_spec("PyQt5") is None:
     subprocess.check_call([sys.executable, "-m", "pip", "install", "PyQt5"])
 from PyQt5 import QtCore as qtc, QtWidgets as qtw


### PR DESCRIPTION
## Summary
- add missing standard library imports to whisper_gui_bootstrap.py

## Testing
- `python -m py_compile whisper_gui_bootstrap.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_689444f2b128832bb044fe47095724ca