### PR TITLE
Add macOS launch script

### DIFF
--- a/macOS/whisper_gui.command
+++ b/macOS/whisper_gui.command
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd "$(dirname "$0")/.."
+if [ -f ".venv/bin/activate" ]; then
+  source ".venv/bin/activate"
+fi
+python whisper_gui_bootstrap.py "$@"


### PR DESCRIPTION
## Summary
- add macOS launch script to start GUI with optional venv activation

## Testing
- `python -m py_compile overlay.py srt_utils.py whisper_gui_bootstrap.py`

------
https://chatgpt.com/codex/tasks/task_e_68a2be4deb2c832bbc90d3a432bc2de0