### PR TITLE
Check translation models before enabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Whisper-srt 是一個利用 OpenAI Whisper 將音訊即時轉換成字幕並於�
 
 ## 設定
 所有設定會儲存在系統的 `QSettings` 中，下次啟動時會自動套用。
+
+## 模型儲存規則
+Whisper 語音模型與翻譯模型下載後會儲存在 `hf_models/<Repo>`，其中 Repo ID 的 `/` 會改為 `--`。
+啟動時程式會優先使用這些本地模型；若資料夾不存在則會改用 Hugging Face 快取或線上下載。

--- a/mWhisperSub.py
+++ b/mWhisperSub.py
@@ -47,12 +47,14 @@ from huggingface_hub import login as hf_login
 
 ROOT_DIR = Path(__file__).resolve().parent
 
-def _repo_local_dir(repo_id: str) -> Path:
+
+def _repo_local_dir(repo_id: str, ensure: bool = False) -> Path:
     d = ROOT_DIR / "hf_models" / repo_id.replace("/", "--")
-    try:
-        d.mkdir(parents=True, exist_ok=True)
-    except Exception:
-        pass
+    if ensure:
+        try:
+            d.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            pass
     return d
 
 # 翻譯模型對應表（來源語言, 目標語言 -> HF Repo ID 清單）

--- a/whisper_gui_bootstrap.py
+++ b/whisper_gui_bootstrap.py
@@ -528,9 +528,34 @@ class BootstrapWin(QtWidgets.QMainWindow):
             model.setData(model.index(i, 0), brush, QtCore.Qt.ForegroundRole)
 
     def _prompt_hf_token(self) -> bool:
-        token, ok = QtWidgets.QInputDialog.getText(
-            self, "Hugging Face Login", "Enter your Hugging Face token:")
-        if not ok or not token:
+        dialog = QtWidgets.QDialog(self)
+        dialog.setWindowTitle("Hugging Face Login")
+        layout = QtWidgets.QVBoxLayout(dialog)
+
+        label = QtWidgets.QLabel(
+            "Enter your Hugging Face token. Get one at "
+            "<a href=\"https://huggingface.co/settings/tokens\">"
+            "https://huggingface.co/settings/tokens</a>"
+        )
+        label.setOpenExternalLinks(True)
+        layout.addWidget(label)
+
+        line_edit = QtWidgets.QLineEdit()
+        line_edit.setEchoMode(QtWidgets.QLineEdit.Password)
+        layout.addWidget(line_edit)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        layout.addWidget(buttons)
+
+        if dialog.exec() != QtWidgets.QDialog.Accepted:
+            return False
+
+        token = line_edit.text().strip()
+        if not token:
             return False
         try:
             from huggingface_hub import login as hf_login

--- a/whisper_gui_bootstrap.py
+++ b/whisper_gui_bootstrap.py
@@ -581,9 +581,8 @@ class BootstrapWin(QtWidgets.QMainWindow):
             except HfHubHTTPError as e:
                 if getattr(getattr(e, "response", None), "status_code", None) == 404:
                     continue
-                return True
             except Exception:
-                return True
+                continue
         return False
 
     def _on_lang_changed(self, idx: int):

--- a/whisper_gui_bootstrap.py
+++ b/whisper_gui_bootstrap.py
@@ -520,16 +520,10 @@ class BootstrapWin(QtWidgets.QMainWindow):
         repos = TRANSLATE_REPO_MAP.get(pair, [])
         if not repos:
             return True
-        try:
-            from huggingface_hub import snapshot_download
-        except Exception:
-            return False
         for repo in repos:
-            try:
-                snapshot_download(repo_id=repo, repo_type="model", local_files_only=True)
+            hf_dir = ROOT_DIR / "hf_models" / repo.replace("/", "--")
+            if hf_dir.exists() and any(hf_dir.iterdir()):
                 return True
-            except Exception:
-                continue
         return False
 
     def _on_lang_changed(self, idx: int):
@@ -563,7 +557,7 @@ class BootstrapWin(QtWidgets.QMainWindow):
         for repo in repos:
             while True:
                 try:
-                    self._download_model_with_progress(repo, use_local_dir=False)
+                    self._download_model_with_progress(repo)
                     return True
                 except Exception as e:
                     err = str(e)

--- a/whisper_gui_bootstrap.py
+++ b/whisper_gui_bootstrap.py
@@ -239,6 +239,12 @@ class BootstrapWin(QtWidgets.QMainWindow):
         self.srt_watcher = None
         self.proc = None  # mWhisperSub 子程序的 handle
 
+        # project autosave
+        self._autosave_timer = QtCore.QTimer(self)
+        self._autosave_timer.setSingleShot(True)
+        self._autosave_timer.timeout.connect(self._do_autosave)
+        self._autosave_pending = False
+
         # 參數設定區
         form_layout = QtWidgets.QFormLayout()
 
@@ -475,11 +481,6 @@ class BootstrapWin(QtWidgets.QMainWindow):
         self._update_model_default()
         self._update_model_default()
         QtCore.QTimer.singleShot(100, self.check_env)
-        # project autosave
-        self._autosave_timer = QtCore.QTimer(self)
-        self._autosave_timer.setSingleShot(True)
-        self._autosave_timer.timeout.connect(self._do_autosave)
-        self._autosave_pending = False
         self._level_timer = QtCore.QTimer(self)
         self._level_timer.timeout.connect(self._poll_mic_level)
         self._level_timer.start(200)

--- a/whisper_gui_bootstrap.py
+++ b/whisper_gui_bootstrap.py
@@ -32,7 +32,8 @@ import importlib.util
 from pathlib import Path
 from functools import lru_cache
 from PyQt5 import QtCore, QtWidgets, QtGui
-from huggingface_hub import HfApi, HfHubError
+from huggingface_hub import HfApi
+from huggingface_hub.utils import HfHubHTTPError
 from project_io import save_project, load_project
 
 # Register text cursor/block types for thread-safe queued connections
@@ -576,7 +577,7 @@ class BootstrapWin(QtWidgets.QMainWindow):
             try:
                 _hf_api.model_info(repo)
                 return True
-            except HfHubError as e:
+            except HfHubHTTPError as e:
                 if getattr(getattr(e, "response", None), "status_code", None) == 404:
                     continue
                 return True

--- a/whisper_gui_bootstrap.py
+++ b/whisper_gui_bootstrap.py
@@ -256,8 +256,6 @@ class BootstrapWin(QtWidgets.QMainWindow):
         self.translate_chk.toggled.connect(self.translate_lang_combo.setEnabled)
         self.translate_lang_combo.currentIndexChanged.connect(self._on_translate_lang_changed)
         self.lang_combo.currentIndexChanged.connect(self._on_lang_changed)
-        self._on_lang_changed(self.lang_combo.currentIndex())
-        self._last_translate_index = self.translate_lang_combo.currentIndex()
         # 翻譯語言僅在勾選翻譯時生效
         form_layout.addRow(self.translate_chk, self.translate_lang_combo)
 
@@ -459,7 +457,6 @@ class BootstrapWin(QtWidgets.QMainWindow):
 
         self._last_model_index = self.model_combo.currentIndex()
         self._refresh_model_items()
-        self._refresh_translate_items()
         QtCore.QTimer.singleShot(100, self.check_env)
         # project autosave
         self._autosave_timer = QtCore.QTimer(self)
@@ -487,6 +484,8 @@ class BootstrapWin(QtWidgets.QMainWindow):
         self.installEventFilter(self)
         # 啟動時嘗試還原上次專案（使用全域 QSettings）
         QtCore.QTimer.singleShot(0, self._auto_open_last_project)
+        self._on_lang_changed(self.lang_combo.currentIndex())
+        self._last_translate_index = self.translate_lang_combo.currentIndex()
         # —— 統一的本地模型資料夾：hf_models/<Repo> —— #
     def _repo_local_dir(self, repo_id: str) -> Path:
         d = (ROOT_DIR / "hf_models" / repo_id.replace("/", "--"))


### PR DESCRIPTION
## Summary
- Mark translation languages as unavailable until their models are downloaded
- Allow users to download translation models on selection and prompt for a Hugging Face token when needed
- Support downloading models either to the local project or the default Hugging Face cache

## Testing
- `python -m py_compile overlay.py srt_utils.py whisper_gui_bootstrap.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4377e1ec8832bb08a6ebd68a807fb